### PR TITLE
Improve SEO metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,7 @@
 name: Andrew Joung, Research Coordinator
+title: "Andrew Joung"
+description: "PhD candidate in Economics researching labor market shocks and intergenerational effects"
+url: "https://anjoung.github.io"
 markdown: kramdown
 
 plugins:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,11 +1,16 @@
 <!DOCTYPE html>
-	<html>
-		<head>
-			<title>{{ page.title }}</title>
-			<!-- link to main stylesheet -->
-			<link rel="stylesheet" type="text/css" href="/css/main.css">
-		</head>
-		<body>
+        <html>
+                <head>
+                        <meta charset="utf-8">
+                        <meta name="viewport" content="width=device-width, initial-scale=1">
+                        <title>{{ page.title }}</title>
+                        <meta name="description" content="{{ page.description | default: site.description }}">
+                        <link rel="canonical" href="{{ page.url | absolute_url }}">
+                        <!-- link to main stylesheet -->
+                        <link rel="stylesheet" type="text/css" href="/css/main.css">
+                        {% seo %}
+                </head>
+                <body>
 			<nav>
 	    		<ul>
 	        		<li><a href="/">Home</a></li>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,12 @@
     <link rel="stylesheet" href="stylesheets/styles.css">
     <link rel="stylesheet" href="stylesheets/github-light.css">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="description" content="Andrew Joung is a PhD candidate in Economics researching labor market shocks and intergenerational effects.">
+    <link rel="canonical" href="https://anjoung.github.io/">
+    <meta property="og:title" content="Andrew Joung">
+    <meta property="og:description" content="PhD candidate in Economics researching labor market shocks and intergenerational effects.">
+    <meta property="og:url" content="https://anjoung.github.io/">
+    <meta property="og:type" content="website">
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->

--- a/papers.html
+++ b/papers.html
@@ -8,6 +8,12 @@
     <link rel="stylesheet" href="stylesheets/styles.css">
     <link rel="stylesheet" href="stylesheets/github-light.css">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="description" content="Research papers by Andrew Joung, a PhD candidate in Economics at the University of Michigan.">
+    <link rel="canonical" href="https://anjoung.github.io/papers.html">
+    <meta property="og:title" content="Andrew Joung - Papers">
+    <meta property="og:description" content="Explore research papers by Andrew Joung, PhD candidate in Economics.">
+    <meta property="og:url" content="https://anjoung.github.io/papers.html">
+    <meta property="og:type" content="article">
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->


### PR DESCRIPTION
## Summary
- add site title, description, and URL configuration
- embed SEO and canonical metadata in default layout and static pages

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68956085201c832096648358918666cc