### PR TITLE
Improve SEO for Andrew Joung search results

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,20 +39,40 @@
         "@context": "https://schema.org",
         "@type": "Person",
         "name": "Andrew Joung",
+        "givenName": "Andrew",
+        "familyName": "Joung",
         "jobTitle": "PhD Candidate in Economics",
         "url": "https://andrewjoung.com",
         "email": "ajoung@umich.edu",
+        "image": "https://andrewjoung.com/image/IMG_4509.jpg",
+        "sameAs": [
+            "https://www.linkedin.com/in/andrew-joung/",
+            "https://scholar.google.com/citations?user=AFNID-EAAAAJ&hl=en"
+        ],
         "affiliation": {
             "@type": "EducationalOrganization",
             "name": "University of Michigan",
             "department": "Department of Economics",
+            "url": "https://lsa.umich.edu/econ",
             "address": {
                 "@type": "PostalAddress",
                 "addressLocality": "Ann Arbor",
-                "addressRegion": "MI"
+                "addressRegion": "MI",
+                "addressCountry": "US"
             }
         },
-        "knowsAbout": ["Labor Economics", "Intergenerational Effects", "Labor Unions", "Minimum Wage", "Self-Employment"]
+        "alumniOf": [
+            {
+                "@type": "EducationalOrganization",
+                "name": "Vassar College"
+            },
+            {
+                "@type": "EducationalOrganization",
+                "name": "University of Pennsylvania",
+                "department": "The Wharton School"
+            }
+        ],
+        "knowsAbout": ["Labor Economics", "Intergenerational Effects", "Labor Unions", "Minimum Wage", "Self-Employment", "Public Economics"]
     }
     </script>
 </head>


### PR DESCRIPTION
- Add sameAs links to LinkedIn and Google Scholar profiles
- Add givenName and familyName for clearer identity
- Add image property
- Add alumniOf for educational history
- Add URL for University of Michigan Economics department